### PR TITLE
feat: add file indexing logic

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -13,7 +13,7 @@
         "test": "node scripts/test-runner.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "/Users/breedloj/workspace/conflicts/language-server-runtimes/runtimes/out",
+        "@aws/language-server-runtimes": "^0.2.56",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "/Users/breedloj/workspace/conflicts/language-server-runtimes/runtimes/out",
+                "@aws/language-server-runtimes": "^0.2.56",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -7591,15 +7591,15 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.55",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.55.tgz",
-            "integrity": "sha512-xdrfDd+pEjztaLl+IAv17ENxkCH8D4xDuoyOomHuo/Jv4BafiPkECirtuo2iWlp6YmnbZ21pxTMnzGh3OyqqCA==",
+            "version": "0.2.56",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.56.tgz",
+            "integrity": "sha512-dO3at4L0msR9BNoRwCKXPAGYGU7dVN53I+tSyY+bJMmTU+Cr3E2O2l4nSjaq8bHU8tVqXNw3DlWudyWRxY4aCw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.11",
+                "@aws/language-server-runtimes-types": "^0.1.12",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "^0.200.0",
                 "@opentelemetry/resources": "^1.30.1",
@@ -7626,9 +7626,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.11",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.11.tgz",
-            "integrity": "sha512-2R6Hteun5hzgmZF0cOgK4qSAzrcixkunxsAxA0cBqJCE/6wvKrN3/S2SR6u4aHAOTsGF3A/46TSDd1Mzr8qzyA==",
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.12.tgz",
+            "integrity": "sha512-9LTQ01MxSkcV8AVs8OsTbb+H1UZ/xgSF7dp9SGPw6y36X3fJxfxvuQVplHyxC5ja+z20ytiWhvD6PE7OF0hc9g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -32352,7 +32352,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.13",
-                "@aws/language-server-runtimes": "/Users/breedloj/workspace/conflicts/language-server-runtimes/runtimes/out",
+                "@aws/language-server-runtimes": "^0.2.56",
                 "@aws/lsp-core": "^0.0.3",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.13",
-        "@aws/language-server-runtimes": "/Users/breedloj/workspace/conflicts/language-server-runtimes/runtimes/out",
+        "@aws/language-server-runtimes": "^0.2.56",
         "@aws/lsp-core": "^0.0.3",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -42,7 +42,10 @@
         "hpagent": "^1.2.0",
         "js-md5": "^0.8.3",
         "uuid": "^11.0.5",
-        "vscode-uri": "^3.1.0"
+        "vscode-uri": "^3.1.0",
+        "fdir": "^6.4.3",
+        "ignore": "^7.0.3",
+        "picomatch": "^4.0.2"
     },
     "devDependencies": {
         "@types/adm-zip": "^0.5.5",

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
@@ -1,0 +1,227 @@
+import { convertChunksToRelevantTextDocuments } from './relevantTextDocuments'
+import { Chunk } from 'local-indexing'
+
+describe('convertChunksToRelevantTextDocuments', () => {
+    it('should convert single chunk correctly', () => {
+        const chunk: Chunk = {
+            filePath: 'test.js',
+            relativePath: 'src/test.js',
+            content: 'console.log("hello")',
+            programmingLanguage: 'javascript',
+            startLine: 1,
+            id: '1',
+            index: 0,
+            vec: [],
+        }
+
+        const result = convertChunksToRelevantTextDocuments([chunk])
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+            relativeFilePath: 'src/test.js',
+            programmingLanguage: { languageName: 'javascript' },
+            text: 'console.log("hello")',
+        })
+    })
+
+    it('should combine multiple chunks from same file', () => {
+        const chunks: Chunk[] = [
+            {
+                filePath: 'test.js',
+                relativePath: 'src/test.js',
+                content: 'const a = 1;',
+                programmingLanguage: 'javascript',
+                startLine: 2,
+                id: '1',
+                index: 0,
+                vec: [],
+            },
+            {
+                filePath: 'test.js',
+                relativePath: 'src/test.js',
+                content: 'console.log(a);',
+                programmingLanguage: 'javascript',
+                startLine: 1,
+                id: '2',
+                index: 1,
+                vec: [],
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+            relativeFilePath: 'src/test.js',
+            programmingLanguage: { languageName: 'javascript' },
+            text: 'console.log(a);\nconst a = 1;',
+        })
+    })
+
+    it('should handle empty or undefined content', () => {
+        const chunks: Chunk[] = [
+            {
+                filePath: 'test.js',
+                relativePath: 'src/test.js',
+                content: '',
+                programmingLanguage: 'javascript',
+                startLine: 1,
+                id: '1',
+                index: 0,
+                vec: [],
+            },
+            {
+                filePath: 'test.js',
+                relativePath: 'src/test.js',
+                content: '',
+                programmingLanguage: 'javascript',
+                startLine: 2,
+                id: '2',
+                index: 1,
+                vec: [],
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+            relativeFilePath: 'src/test.js',
+            programmingLanguage: { languageName: 'javascript' },
+        })
+    })
+
+    it('should handle unsupported programming language', () => {
+        const chunk: Chunk = {
+            filePath: 'test.xyz',
+            relativePath: 'src/test.xyz',
+            content: 'some content',
+            programmingLanguage: 'unsupported',
+            startLine: 1,
+            id: '1',
+            index: 0,
+            vec: [],
+        }
+
+        const result = convertChunksToRelevantTextDocuments([chunk])
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+            relativeFilePath: 'src/test.xyz',
+            text: 'some content',
+        })
+    })
+
+    it('should truncate relative file path if exceeds limit', () => {
+        const longPath = 'a'.repeat(5000)
+        const chunk: Chunk = {
+            filePath: 'test.js',
+            relativePath: longPath,
+            content: 'console.log("hello")',
+            programmingLanguage: 'javascript',
+            startLine: 1,
+            id: '1',
+            index: 0,
+            vec: [],
+        }
+
+        const result = convertChunksToRelevantTextDocuments([chunk])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].relativeFilePath?.length).toBe(4000)
+    })
+
+    it('should handle multiple files', () => {
+        const chunks: Chunk[] = [
+            {
+                filePath: 'test1.js',
+                relativePath: 'src/test1.js',
+                content: 'file1 content',
+                programmingLanguage: 'javascript',
+                startLine: 1,
+                id: '1',
+                index: 0,
+                vec: [],
+            },
+            {
+                filePath: 'test2.js',
+                relativePath: 'src/test2.js',
+                content: 'file2 content',
+                programmingLanguage: 'javascript',
+                startLine: 1,
+                id: '2',
+                index: 1,
+                vec: [],
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+
+        expect(result).toHaveLength(2)
+        expect(result[0].text).toBe('file1 content')
+        expect(result[1].text).toBe('file2 content')
+    })
+
+    it('should handle chunks without relativePath', () => {
+        const chunk: Chunk = {
+            filePath: 'test.js',
+            content: 'console.log("hello")',
+            programmingLanguage: 'javascript',
+            startLine: 1,
+            id: '1',
+            index: 0,
+            vec: [],
+        }
+
+        const result = convertChunksToRelevantTextDocuments([chunk])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].relativeFilePath).toBeUndefined()
+    })
+
+    it('should handle chunks without startLine', () => {
+        const chunks: Chunk[] = [
+            {
+                filePath: 'test.js',
+                relativePath: 'src/test.js',
+                content: 'const a = 1;',
+                programmingLanguage: 'javascript',
+                id: '1',
+                index: 0,
+                vec: [],
+            },
+            {
+                filePath: 'test.js',
+                relativePath: 'src/test.js',
+                content: 'console.log(a);',
+                programmingLanguage: 'javascript',
+                id: '2',
+                index: 1,
+                vec: [],
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0].text).toBe('const a = 1;\nconsole.log(a);')
+    })
+
+    it('should not include documentSymbols in the result', () => {
+        const chunk: Chunk = {
+            filePath: 'test.js',
+            relativePath: 'src/test.js',
+            content: 'console.log("hello")',
+            programmingLanguage: 'javascript',
+            startLine: 1,
+            id: '1',
+            index: 0,
+            vec: [],
+        }
+
+        const result = convertChunksToRelevantTextDocuments([chunk])
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).not.toHaveProperty('documentSymbols')
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.ts
@@ -1,0 +1,59 @@
+import { Chunk } from 'local-indexing'
+import { ProgrammingLanguage, RelevantTextDocument } from '@amzn/codewhisperer-streaming'
+import { languageByExtension } from '../../../shared/languageDetection'
+
+const supportedLanguages = Object.keys(languageByExtension)
+
+export function convertChunksToRelevantTextDocuments(chunks: Chunk[]): RelevantTextDocument[] {
+    const filePathSizeLimit = 4_000
+
+    const groupedChunks = chunks.reduce(
+        (acc, chunk) => {
+            const key = chunk.filePath
+            if (!acc[key]) {
+                acc[key] = []
+            }
+            acc[key].push(chunk)
+            return acc
+        },
+        {} as Record<string, Chunk[]>
+    )
+
+    return Object.entries(groupedChunks).map(([filePath, fileChunks]) => {
+        fileChunks.sort((a, b) => {
+            if (a.startLine !== undefined && b.startLine !== undefined) {
+                return a.startLine - b.startLine
+            }
+            return 0
+        })
+
+        const firstChunk = fileChunks[0]
+
+        let programmingLanguage: ProgrammingLanguage | undefined
+        if (
+            firstChunk.programmingLanguage &&
+            supportedLanguages.includes(firstChunk.programmingLanguage.toLowerCase())
+        ) {
+            programmingLanguage = {
+                languageName: firstChunk.programmingLanguage,
+            }
+        }
+
+        const combinedContent = fileChunks
+            .map(chunk => chunk.content)
+            .filter(content => content !== undefined && content !== '')
+            .join('\n')
+
+        const relevantTextDocument: RelevantTextDocument = {
+            relativeFilePath: firstChunk.relativePath
+                ? firstChunk.relativePath.substring(0, filePathSizeLimit)
+                : undefined,
+            programmingLanguage,
+            text: combinedContent || undefined,
+        }
+
+        return Object.fromEntries(
+            Object.entries(relevantTextDocument).filter(([_, value]) => value !== undefined)
+        ) as RelevantTextDocument
+    })
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextController.test.ts
@@ -1,0 +1,256 @@
+import { LocalProjectContextController } from './localProjectContextController'
+import { SinonStub, stub, spy, assert as sinonAssert } from 'sinon'
+import * as assert from 'assert'
+import * as fs from 'fs'
+import { Dirent } from 'fs'
+import sinon from 'ts-sinon'
+
+class LoggingMock {
+    public error: SinonStub
+    public info: SinonStub
+    public log: SinonStub
+    public warn: SinonStub
+
+    constructor() {
+        this.error = stub()
+        this.info = stub()
+        this.log = stub()
+        this.warn = stub()
+    }
+}
+
+describe('LocalProjectContextController', () => {
+    let controller: LocalProjectContextController
+    let logging: LoggingMock
+    let mockWorkspaceFolders: any[]
+    let vectorLibMock: any
+    let fsStub: SinonStub
+
+    beforeEach(() => {
+        logging = new LoggingMock()
+        mockWorkspaceFolders = [
+            {
+                uri: 'file:///path/to/workspace1',
+                name: 'workspace1',
+            },
+        ]
+
+        vectorLibMock = {
+            start: stub().resolves({
+                buildIndex: stub().resolves(),
+                clear: stub().resolves(),
+                queryVectorIndex: stub().resolves(['mockChunk1', 'mockChunk2']),
+                queryInlineProjectContext: stub().resolves(['mockContext1']),
+                updateIndexV2: stub().resolves(),
+            }),
+        }
+
+        fsStub = stub(fs.promises, 'readdir')
+        fsStub
+            .withArgs('/path/to/workspace1', { withFileTypes: true })
+            .resolves([createMockDirent('Test.java', false), createMockDirent('src', true)])
+        fsStub
+            .withArgs('/path/to/workspace1/src', { withFileTypes: true })
+            .resolves([createMockDirent('Main.java', false)])
+
+        controller = new LocalProjectContextController('testClient', mockWorkspaceFolders, logging as any)
+    })
+
+    afterEach(() => {
+        fsStub.restore()
+    })
+
+    describe('init', () => {
+        it('should initialize vector library successfully', async () => {
+            await controller.init(vectorLibMock)
+
+            sinonAssert.notCalled(logging.error)
+            sinonAssert.called(vectorLibMock.start)
+            const vecLib = await vectorLibMock.start()
+            sinonAssert.called(vecLib.buildIndex)
+        })
+
+        it('should handle initialization errors', async () => {
+            vectorLibMock.start.rejects(new Error('Init failed'))
+
+            await controller.init(vectorLibMock)
+
+            sinonAssert.called(logging.error)
+        })
+    })
+
+    describe('queryVectorIndex', () => {
+        beforeEach(async () => {
+            await controller.init(vectorLibMock)
+        })
+
+        it('should return empty chunks when vector library is not initialized', async () => {
+            const uninitializedController = new LocalProjectContextController(
+                'testClient',
+                mockWorkspaceFolders,
+                logging as any
+            )
+
+            const result = await uninitializedController.queryVectorIndex({ query: 'test' })
+            assert.deepStrictEqual(result, { chunks: [] })
+        })
+
+        it('should return chunks from vector library', async () => {
+            const result = await controller.queryVectorIndex({ query: 'test' })
+            assert.deepStrictEqual(result, { chunks: ['mockChunk1', 'mockChunk2'] })
+        })
+
+        it('should handle query errors', async () => {
+            const vecLib = await vectorLibMock.start()
+            vecLib.queryVectorIndex.rejects(new Error('Query failed'))
+
+            const result = await controller.queryVectorIndex({ query: 'test' })
+            assert.deepStrictEqual(result, { chunks: [] })
+            sinonAssert.called(logging.error)
+        })
+    })
+
+    describe('queryInlineProjectContext', () => {
+        beforeEach(async () => {
+            await controller.init(vectorLibMock)
+        })
+
+        it('should return empty context when vector library is not initialized', async () => {
+            const uninitializedController = new LocalProjectContextController(
+                'testClient',
+                mockWorkspaceFolders,
+                logging as any
+            )
+
+            const result = await uninitializedController.queryInlineProjectContext({
+                query: 'test',
+                filePath: 'test.java',
+                target: 'test',
+            })
+            assert.deepStrictEqual(result, { inlineProjectContext: [] })
+        })
+
+        it('should return context from vector library', async () => {
+            const result = await controller.queryInlineProjectContext({
+                query: 'test',
+                filePath: 'test.java',
+                target: 'test',
+            })
+            assert.deepStrictEqual(result, { inlineProjectContext: ['mockContext1'] })
+        })
+
+        it('should handle query errors', async () => {
+            const vecLib = await vectorLibMock.start()
+            vecLib.queryInlineProjectContext.rejects(new Error('Query failed'))
+
+            const result = await controller.queryInlineProjectContext({
+                query: 'test',
+                filePath: 'test.java',
+                target: 'test',
+            })
+            assert.deepStrictEqual(result, { inlineProjectContext: [] })
+            sinonAssert.called(logging.error)
+        })
+    })
+
+    describe('updateIndex', () => {
+        beforeEach(async () => {
+            await controller.init(vectorLibMock)
+        })
+
+        it('should do nothing when vector library is not initialized', async () => {
+            const uninitializedController = new LocalProjectContextController(
+                'testClient',
+                mockWorkspaceFolders,
+                logging as any
+            )
+
+            await uninitializedController.updateIndex(['test.java'], 'add')
+            sinonAssert.notCalled(logging.error)
+        })
+
+        it('should update index successfully', async () => {
+            const vecLib = await vectorLibMock.start()
+            await controller.updateIndex(['test.java'], 'add')
+            sinonAssert.called(vecLib.updateIndexV2)
+        })
+
+        it('should handle update errors', async () => {
+            const vecLib = await vectorLibMock.start()
+            vecLib.updateIndexV2.rejects(new Error('Update failed'))
+
+            await controller.updateIndex(['test.java'], 'add')
+            sinonAssert.called(logging.error)
+        })
+    })
+
+    describe('findCommonWorkspaceRoot', () => {
+        it('should return single workspace path when only one workspace exists', () => {
+            const singleWorkspace = [
+                {
+                    uri: 'file:///path/to/workspace',
+                    name: 'workspace',
+                },
+            ]
+
+            const result = (controller as any).findCommonWorkspaceRoot(singleWorkspace)
+            assert.strictEqual(result, '/path/to/workspace')
+        })
+
+        it('should throw error when no workspaces provided', () => {
+            assert.throws(() => (controller as any).findCommonWorkspaceRoot([]), Error, 'No workspace folders provided')
+        })
+
+        it('should find common root between multiple workspaces', () => {
+            const multipleWorkspaces = [
+                { uri: 'file:///path/to/workspace1', name: 'workspace1' },
+                { uri: 'file:///path/to/workspace2', name: 'workspace2' },
+            ]
+
+            const result = (controller as any).findCommonWorkspaceRoot(multipleWorkspaces)
+            assert.strictEqual(result, '/path/to')
+        })
+    })
+
+    describe('getCodeSourceFiles', () => {
+        it('should return java files from directory', async () => {
+            const results = await (controller as any).getCodeSourceFiles('/path/to/workspace1')
+
+            assert.deepStrictEqual(results, ['/path/to/workspace1/Test.java', '/path/to/workspace1/src/Main.java'])
+        })
+
+        it('should handle directory read errors', async () => {
+            fsStub.withArgs('/path/to/error', { withFileTypes: true }).rejects(new Error('Read error'))
+
+            const results = await (controller as any).getCodeSourceFiles('/path/to/error')
+            assert.deepStrictEqual(results, [])
+            sinonAssert.calledWith(logging.error, sinon.match(/Error reading directory \/path\/to\/error/))
+        })
+    })
+
+    describe('dispose', () => {
+        it('should clear and remove vector library reference', async () => {
+            await controller.init(vectorLibMock)
+            await controller.dispose()
+
+            const vecLib = await vectorLibMock.start()
+            sinonAssert.called(vecLib.clear)
+
+            const queryResult = await controller.queryVectorIndex({ query: 'test' })
+            assert.deepStrictEqual(queryResult, { chunks: [] })
+        })
+    })
+})
+
+function createMockDirent(name: string, isDirectory: boolean): Dirent {
+    return {
+        name,
+        isDirectory: () => isDirectory,
+        isFile: () => !isDirectory,
+        isBlockDevice: () => false,
+        isCharacterDevice: () => false,
+        isFIFO: () => false,
+        isSocket: () => false,
+        isSymbolicLink: () => false,
+    } as Dirent
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextController.ts
@@ -172,8 +172,7 @@ export class LocalProjectContextController {
         const { signal } = controller
 
         const workspaceSourceFiles = workspaceFolders.reduce((allFiles: string[], folder: WorkspaceFolder) => {
-            const relativePath = path.relative(process.cwd(), folder.uri)
-            const absolutePath = path.resolve(folder.uri)
+            const absolutePath = path.resolve(new URL(folder.uri).pathname)
 
             const crawler = new fdir()
                 .withSymlinks({ resolvePaths: !includeSymLinks })
@@ -198,7 +197,7 @@ export class LocalProjectContextController {
                     )
                 })
 
-            const sourceFiles = crawler.crawl(relativePath).sync()
+            const sourceFiles = crawler.crawl(absolutePath).sync()
 
             return [...allFiles, ...sourceFiles]
         }, [] as string[])

--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextController.ts
@@ -6,44 +6,45 @@ import {
     QueryVectorIndexResult,
     WorkspaceFolder,
 } from '@aws/language-server-runtimes/server-interface'
-import { Features } from '../types'
-//import { Q_CONFIGURATION_SECTION } from '../configuration/qConfigurationServer'
-import { TelemetryService } from '../../shared/telemetry/telemetryService'
+import { dirname } from 'path'
 import { languageByExtension } from '../../shared/languageDetection'
 import type { UpdateMode, VectorLibAPI } from 'local-indexing'
 
 const fs = require('fs').promises
 const path = require('path')
-const LIBRARY_DIR = '/Users/breedloj/Downloads/context/qserver'
+const LIBRARY_DIR = path.join(dirname(require.main!.filename), 'indexing')
 
 export class LocalProjectContextController {
-    private readonly features: Features
-    private readonly telemetryService: TelemetryService
+    private static instance: LocalProjectContextController | undefined
+
     private readonly fileExtensions: string[]
     private readonly workspaceFolders: WorkspaceFolder[]
     private readonly clientName: string
     private _vecLib?: VectorLibAPI
+    private log: Logging
 
-    constructor(
-        features: Features,
-        telemetryService: TelemetryService,
-        clientName: string,
-        workspaceFolders: WorkspaceFolder[],
-        log: Logging
-    ) {
-        this.features = features
-        this.telemetryService = telemetryService
+    constructor(clientName: string, workspaceFolders: WorkspaceFolder[], logging: Logging) {
         this.fileExtensions = Object.keys(languageByExtension)
         this.workspaceFolders = workspaceFolders
         this.clientName = clientName
+        this.log = logging
     }
 
-    public async init(): Promise<void> {
+    public static getInstance() {
+        if (!this.instance) {
+            throw new Error('LocalProjectContextController not initialized')
+        }
+        return this.instance
+    }
+
+    public async init(vectorLib?: any): Promise<void> {
         try {
-            const vectorLib = await import(path.join(LIBRARY_DIR, 'dist', 'extension.js'))
-            this._vecLib = await vectorLib.start(LIBRARY_DIR, this.clientName, 'some_path')
+            const vecLib = vectorLib ?? (await import(path.join(LIBRARY_DIR, 'dist', 'extension.js')))
+            const root = this.findCommonWorkspaceRoot(this.workspaceFolders)
+            this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, root)
+            LocalProjectContextController.instance = this
         } catch (error) {
-            this.log('Vector library failed to initialize:' + error)
+            this.log.error('Vector library failed to initialize:' + error)
         }
         await this.updateConfiguration()
     }
@@ -57,19 +58,13 @@ export class LocalProjectContextController {
 
     public async updateConfiguration(): Promise<void> {
         try {
-            // const qConfig = await this.features.lsp.workspace.getConfiguration(Q_CONFIGURATION_SECTION)
-            // if (qConfig) {
-            //     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
-            //     this.telemetryService.updateOptOutPreference(optOutTelemetryPreference)
-            // }
-
             if (this._vecLib) {
                 const sourceFiles = await this.processWorkspaceFolders(this.workspaceFolders)
                 const rootDir = this.findCommonWorkspaceRoot(this.workspaceFolders)
                 await this._vecLib?.buildIndex(sourceFiles, rootDir, 'all')
             }
         } catch (error) {
-            this.log(`Error in GetConfiguration: ${error}`)
+            this.log.error(`Error in GetConfiguration: ${error}`)
         }
     }
 
@@ -81,7 +76,7 @@ export class LocalProjectContextController {
         try {
             await this._vecLib?.updateIndexV2(filePaths, operation)
         } catch (error) {
-            this.log(`Error updating index: ${error}`)
+            this.log.error(`Error updating index: ${error}`)
         }
     }
 
@@ -96,7 +91,7 @@ export class LocalProjectContextController {
             const resp = await this._vecLib?.queryInlineProjectContext(params.query, params.filePath, params.target)
             return { inlineProjectContext: resp ?? [] }
         } catch (error) {
-            this.log(`Error in queryInlineProjectContext: ${error}`)
+            this.log.error(`Error in queryInlineProjectContext: ${error}`)
             return { inlineProjectContext: [] }
         }
     }
@@ -110,7 +105,7 @@ export class LocalProjectContextController {
             const resp = await this._vecLib?.queryVectorIndex(params.query)
             return { chunks: resp ?? [] }
         } catch (error) {
-            this.log(`Error in queryVectorIndex: ${error}`)
+            this.log.error(`Error in queryVectorIndex: ${error}`)
             return { chunks: [] }
         }
     }
@@ -120,33 +115,38 @@ export class LocalProjectContextController {
         if (workspaceFolders) {
             for (const folder of workspaceFolders) {
                 const folderPath = new URL(folder.uri).pathname
-                this.log(`Processing workspace: ${folder.name}`)
+                this.log.info(`Processing workspace: ${folder.name}`)
 
                 try {
                     const sourceFiles = await this.getCodeSourceFiles(folderPath)
                     workspaceSourceFiles.push(...sourceFiles)
                 } catch (error) {
-                    this.log(`Error processing ${folder.name}: ${error}`)
+                    this.log.error(`Error processing ${folder.name}: ${error}`)
                 }
             }
         }
-        this.log(`Found ${workspaceSourceFiles.length} source files`)
+        this.log.info(`Found ${workspaceSourceFiles.length} source files`)
         return workspaceSourceFiles
     }
 
     private async getCodeSourceFiles(dir: string): Promise<string[]> {
-        const files = await fs.readdir(dir, { withFileTypes: true })
-        const sourceFiles: string[] = []
+        try {
+            const files = await fs.readdir(dir, { withFileTypes: true })
+            const sourceFiles: string[] = []
 
-        for (const file of files) {
-            const filePath = path.join(dir, file.name)
-            if (file.isDirectory()) {
-                sourceFiles.push(...(await this.getCodeSourceFiles(filePath)))
-            } else if (this.fileExtensions.includes(path.extname(file.name).toLowerCase())) {
-                sourceFiles.push(filePath)
+            for (const file of files) {
+                const filePath = path.join(dir, file.name)
+                if (file.isDirectory()) {
+                    sourceFiles.push(...(await this.getCodeSourceFiles(filePath)))
+                } else if (this.fileExtensions.includes(path.extname(file.name).toLowerCase())) {
+                    sourceFiles.push(filePath)
+                }
             }
+            return sourceFiles
+        } catch (error) {
+            this.log.error(`Error reading directory ${dir}: ${error}`)
+            return []
         }
-        return sourceFiles
     }
 
     private findCommonWorkspaceRoot(workspaceFolders: WorkspaceFolder[]): string {
@@ -175,9 +175,5 @@ export class LocalProjectContextController {
             return new URL(workspaceFolders[0].uri).pathname
         }
         return path.sep + splitPaths[0].slice(0, lastMatchingIndex + 1).join(path.sep)
-    }
-
-    private log(...messages: string[]) {
-        this.features.logging.log(messages.join(' '))
     }
 }


### PR DESCRIPTION
## Problem
When the LSP is initialized, local project context needs to crawl the workspaces, build a repo map, create an index with it that will be used to provide additional context to Q.

## Solution
Added file indexing logic using the fdir library for crawling the workspace folders and ignore library to handle file/folder exclusion rules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
